### PR TITLE
allow to search in different countries

### DIFF
--- a/lib/rebay/api.rb
+++ b/lib/rebay/api.rb
@@ -6,7 +6,7 @@ module Rebay
   class Api
     # default site is EBAY_US, for other available sites see eBay documentation:
     # http://developer.ebay.com/DevZone/merchandising/docs/Concepts/SiteIDToGlobalID.html
-    EBAY_US = 0
+    EBAY_US = "EBAY-US"
 
     class << self
       attr_accessor :app_id, :default_site_id, :sandbox

--- a/lib/rebay/finding.rb
+++ b/lib/rebay/finding.rb
@@ -94,7 +94,7 @@ module Rebay
     
     private    
     def build_request_url(service, params=nil)
-      url = "#{self.class.base_url}?OPERATION-NAME=#{service}&SERVICE-VERSION=#{VERSION}&SECURITY-APPNAME=#{Rebay::Api.app_id}&RESPONSE-DATA-FORMAT=JSON&REST-PAYLOAD"
+      url = "#{self.class.base_url}?OPERATION-NAME=#{service}&SERVICE-VERSION=#{VERSION}&SECURITY-APPNAME=#{Rebay::Api.app_id}&X-EBAY-SOA-GLOBAL-ID=#{Rebay::Api.default_site_id}&RESPONSE-DATA-FORMAT=JSON&REST-PAYLOAD"
       url += build_rest_payload(params)
       return url
     end

--- a/lib/rebay/shopping.rb
+++ b/lib/rebay/shopping.rb
@@ -128,7 +128,7 @@ module Rebay
 
     private
     def build_request_url(service, params=nil)
-      url = "#{self.class.base_url}?callname=#{service}&appid=#{Rebay::Api.app_id}&version=#{VERSION}&responseencoding=JSON"
+      url = "#{self.class.base_url}?callname=#{service}&appid=#{Rebay::Api.app_id}&X-EBAY-SOA-GLOBAL-ID=#{Rebay::Api.default_site_id}&version=#{VERSION}&responseencoding=JSON"
       url += build_rest_payload({siteid: Rebay::Api.default_site_id}.merge(params))
       return url
     end

--- a/spec/shopping_spec.rb
+++ b/spec/shopping_spec.rb
@@ -17,19 +17,19 @@ module Rebay
 
     context "siteid" do
       it "should default siteid" do
-        @shopper.should_receive(:get_json_response).with(/siteid=0&/)
+        @shopper.should_receive(:get_json_response).with(/EBAY-SOA-GLOBAL-ID=EBAY-US&/)
         @shopper.get_category_info(:CategoryID => '-1')
       end
 
       it "should default siteid" do
-        Rebay::Api.default_site_id = 100
-        @shopper.should_receive(:get_json_response).with(/siteid=100&/)
+        Rebay::Api.default_site_id = "EBAY-IT"
+        @shopper.should_receive(:get_json_response).with(/EBAY-SOA-GLOBAL-ID=EBAY-IT&/)
         @shopper.get_category_info(:CategoryID => '-1')
       end
 
       it "should default siteid" do
-        Rebay::Api.default_site_id = 100
-        @shopper.should_receive(:get_json_response).with(/siteid=99&/)
+        Rebay::Api.default_site_id = "EBAY-MOTOR"
+        @shopper.should_receive(:get_json_response).with(/EBAY-SOA-GLOBAL-ID=EBAY-MOTOR&/)
         @shopper.get_category_info(:CategoryID => '-1', :siteid => 99)
       end
     end


### PR DESCRIPTION
 Fixed default Global ID issue. Client can now set default_site_id equal to any of the Global ID values listed on https://developer.ebay.com/DevZone/merchandising/docs/CallRef/Enums/GlobalIdList.html.  If a Global ID is not supplied, the application will default to EBAY-USA

